### PR TITLE
Add support for sharing data between `vfile` and `vinyl`

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ function buffer(vinyl, options, callback) {
     }
 
     vinyl.contents = contents
+    vinyl.data = vfile.data
 
     callback(null, vinyl)
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "index.js"
   ],
   "dependencies": {
-    "convert-vinyl-to-vfile": "^2.0.0",
+    "convert-vinyl-to-vfile": "^2.1.2",
     "plugin-error": "^1.0.1",
     "through2": "^3.0.0",
     "unified-engine": "^8.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ var report = [
 ].join('\n')
 
 test('unified-engine-gulp', function (t) {
-  t.plan(8)
+  t.plan(9)
 
   t.test('configuring', function (st) {
     st.throws(
@@ -147,5 +147,30 @@ test('unified-engine-gulp', function (t) {
         st.equal(String(stderr()), report, 'should report')
       })
       .write(new File({path: 'readme.md', contents: Buffer.from(input)}))
+  })
+
+  t.test('custom data', function (st) {
+    var stderr = spy()
+
+    st.plan(1)
+
+    function customData() {
+      return function (tree, file) {
+        file.data.value = 'changed'
+      }
+    }
+
+    example({streamError: stderr.stream})
+      .use(customData)
+      .once('data', function (file) {
+        st.equal(file.data.value, 'changed')
+      })
+      .write(
+        new File({
+          path: 'readme.md',
+          contents: Buffer.from(input),
+          data: {value: 'original'}
+        })
+      )
   })
 })


### PR DESCRIPTION
gulp-data standardized saving custom data to the `data` property, so I'm updating convert-vinyl-to-vfile because the latest version forwards vinyl data to vfile for any unified plugin which might use it, like [rehype-meta](https://www.npmjs.com/package/rehype-meta), and after processing I'm saving it back to the vinyl file in case any unified plugin modified it.

One use case is for parsing and saving data from [remark-frontmatter](https://www.npmjs.com/package/remark-frontmatter) to make it available to gulp plugins down the stream.

This is a barebones example with gulp-wrap:

```js
const remark = require('gulp-remark')
const html = require('remark-html')
const wrap = require('gulp-wrap')

const saveData = () => (tree, file) => {
  file.data.foo = 'foo'
}

// ...
.pipe(remark().use(saveData).use(html))
.pipe(wrap('<%= file.data.foo %> <%= contents %>'))
```
